### PR TITLE
Anthony/fix provisioning

### DIFF
--- a/pkg/bitbucket/client.go
+++ b/pkg/bitbucket/client.go
@@ -924,13 +924,13 @@ func (c *Client) doRequest(
 
 		// Decode the JSON response body into the ErrorResponse struct
 		if err := json.NewDecoder(rawResponse.Body).Decode(&errResp); err != nil {
-			return status.Error(codes.Code(rawResponse.StatusCode), "Request failed with unknown error")
+			return status.Error(codes.Unknown, "Request failed with unknown error")
 		}
 
 		// Construct a more detailed error message
-		errMsg := fmt.Sprintf("Request failed with status %d: %s", rawResponse.StatusCode, errResp.Error.Message)
+		errMsg := fmt.Sprintf("Request failed with gRPC status %d: %s", rawResponse.StatusCode, errResp.Error.Message)
 
-		return status.Errorf(codes.Code(rawResponse.StatusCode), errMsg)
+		return status.Error(codes.Unknown, errMsg)
 	}
 
 	if method != http.MethodDelete {

--- a/pkg/bitbucket/client.go
+++ b/pkg/bitbucket/client.go
@@ -60,7 +60,6 @@ type ListResponse[T any] struct {
 }
 
 type errorResponse struct {
-	Type  string `json:"type"`
 	Error struct {
 		Message string `json:"message"`
 	} `json:"error"`

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -1,6 +1,7 @@
 package connector
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/conductorone/baton-bitbucket/pkg/bitbucket"
@@ -74,4 +75,19 @@ func splitFullName(fullName string) (string, string) {
 func GetIdFromComposedId(resource *v2.Resource) string {
 	parts := strings.Split(resource.Id.Resource, ":")
 	return parts[len(parts)-1]
+}
+
+func ParseEntitlementID(id string) (*v2.ResourceId, string, error) {
+	parts := strings.Split(id, ":")
+
+	// Need to be at least 3 parts type:entitlement_id:slug
+	if len(parts) < 4 {
+		return nil, "", fmt.Errorf("bitbucket-connector: invalid resource id")
+	}
+
+	resourceId := &v2.ResourceId{
+		ResourceType: parts[0],
+		Resource:     strings.Join(parts[1:len(parts)-1], ":"),
+	}
+	return resourceId, parts[len(parts)-1], nil
 }

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -1,7 +1,6 @@
 package connector
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/conductorone/baton-bitbucket/pkg/bitbucket"
@@ -72,12 +71,7 @@ func splitFullName(fullName string) (string, string) {
 	return parts[0], strings.Join(parts[1:], " ")
 }
 
-func ExtractValueFromId(id string, prefix string) (string, error) {
-	parts := strings.SplitN(id, prefix, 2)
-	if len(parts) < 2 {
-		return "", fmt.Errorf("invalid id:%s is missing '%s' prefix", id, prefix)
-	}
-
-	// Extract the part after the prefix
-	return strings.SplitN(parts[1], ":", 2)[0], nil
+func GetIdFromComposedId(resource *v2.Resource) string {
+	parts := strings.Split(resource.Id.Resource, ":")
+	return parts[len(parts)-1]
 }

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -1,6 +1,7 @@
 package connector
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/conductorone/baton-bitbucket/pkg/bitbucket"
@@ -69,4 +70,14 @@ func splitFullName(fullName string) (string, string) {
 	parts := strings.Split(fullName, " ")
 
 	return parts[0], strings.Join(parts[1:], " ")
+}
+
+func ExtractValueFromId(id string, prefix string) (string, error) {
+	parts := strings.SplitN(id, prefix, 2)
+	if len(parts) < 2 {
+		return "", fmt.Errorf("invalid id:%s is missing '%s' prefix", id, prefix)
+	}
+
+	// Extract the part after the prefix
+	return strings.SplitN(parts[1], ":", 2)[0], nil
 }

--- a/pkg/connector/project.go
+++ b/pkg/connector/project.go
@@ -492,9 +492,9 @@ func (p *projectResourceType) Revoke(ctx context.Context, grant *v2.Grant) (anno
 	}
 
 	// warn if the principal already has a project permission
-	if permission.Value != roleNone {
+	if permission.Value == roleNone {
 		l.Warn(
-			"bitbucket-connector: principal already has a project permission",
+			"bitbucket-connector: principal already doesnt have this project permission",
 		)
 	}
 

--- a/pkg/connector/project.go
+++ b/pkg/connector/project.go
@@ -491,7 +491,7 @@ func (p *projectResourceType) Revoke(ctx context.Context, grant *v2.Grant) (anno
 		return nil, fmt.Errorf("bitbucket-connector: unsupported project role: %s", permission.Value)
 	}
 
-	// warn if the principal already has a project permission
+	// warn if the principal already doesnt have this project permission
 	if permission.Value == roleNone {
 		l.Warn(
 			"bitbucket-connector: principal already doesnt have this project permission",

--- a/pkg/connector/project.go
+++ b/pkg/connector/project.go
@@ -202,7 +202,7 @@ func (p *projectResourceType) Grants(ctx context.Context, resource *v2.Resource,
 
 		for _, repo := range repos {
 			repoCopy := repo
-			rr, err := repositoryResource(ctx, &repoCopy, resource.ParentResourceId)
+			rr, err := repositoryResource(ctx, &repoCopy, &v2.ResourceId{Resource: resource.Id.Resource})
 			if err != nil {
 				return nil, "", nil, err
 			}
@@ -245,7 +245,7 @@ func (p *projectResourceType) Grants(ctx context.Context, resource *v2.Resource,
 
 			groupCopy := permission.Group
 
-			gr, err := userGroupResource(ctx, &groupCopy, resource.ParentResourceId)
+			gr, err := userGroupResource(ctx, &groupCopy, &v2.ResourceId{Resource: workspaceId})
 			if err != nil {
 				return nil, "", nil, err
 			}
@@ -288,7 +288,7 @@ func (p *projectResourceType) Grants(ctx context.Context, resource *v2.Resource,
 
 			userCopy := permission.User
 
-			ur, err := userResource(ctx, &userCopy, resource.ParentResourceId)
+			ur, err := userResource(ctx, &userCopy, &v2.ResourceId{Resource: workspaceId})
 			if err != nil {
 				return nil, "", nil, err
 			}

--- a/pkg/connector/repository.go
+++ b/pkg/connector/repository.go
@@ -178,7 +178,8 @@ func (r *repositoryResourceType) Grants(ctx context.Context, resource *v2.Resour
 
 			groupCopy := permission.Group
 
-			gr, err := userGroupResource(ctx, &groupCopy, resource.ParentResourceId)
+			gr, err := userGroupResource(ctx, &groupCopy, &v2.ResourceId{Resource: workspaceId})
+
 			if err != nil {
 				return nil, "", nil, err
 			}
@@ -221,7 +222,7 @@ func (r *repositoryResourceType) Grants(ctx context.Context, resource *v2.Resour
 
 			memberCopy := permission.User
 
-			ur, err := userResource(ctx, &memberCopy, resource.ParentResourceId)
+			ur, err := userResource(ctx, &memberCopy, &v2.ResourceId{Resource: workspaceId})
 			if err != nil {
 				return nil, "", nil, err
 			}

--- a/pkg/connector/repository.go
+++ b/pkg/connector/repository.go
@@ -41,7 +41,7 @@ func DecomposeRepositoryId(repositoryId string) (string, string, error) {
 
 	// Check if the project id is valid
 	projectId := strings.Join(parts[0:len(parts)-1], ":")
-	if _, _, err := DecomposeProjectId(projectId); err != nil {
+	if _, _, _, err := DecomposeProjectId(projectId); err != nil {
 		return "", "", errors.New("bitbucket-connector: invalid repository resource id, composed project id is invalid")
 	}
 
@@ -60,7 +60,7 @@ func repositoryResource(ctx context.Context, repository *bitbucket.Repository, p
 	resource, err := rs.NewGroupResource(
 		repository.FullName,
 		resourceTypeRepository,
-		ComposeProjectId(parentResourceID.Resource, repository.Id),
+		ComposeRepositoryId(parentResourceID.Resource, repository.Id),
 		[]rs.GroupTraitOption{
 			rs.WithGroupProfile(profile),
 		},
@@ -85,7 +85,7 @@ func (r *repositoryResourceType) List(ctx context.Context, parentId *v2.Resource
 		return nil, "", nil, err
 	}
 
-	workspaceId, projectId, err := DecomposeProjectId(parentId.Resource)
+	workspaceId, projectId, _, err := DecomposeProjectId(parentId.Resource)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -155,7 +155,7 @@ func (r *repositoryResourceType) Grants(ctx context.Context, resource *v2.Resour
 		return nil, "", nil, err
 	}
 
-	workspaceId, _, err := DecomposeProjectId(composedProjectId)
+	workspaceId, _, _, err := DecomposeProjectId(composedProjectId)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -331,7 +331,7 @@ func (r *repositoryResourceType) Grant(ctx context.Context, principal *v2.Resour
 		return nil, err
 	}
 
-	workspaceId, _, err := DecomposeProjectId(composedProjectId)
+	workspaceId, _, _, err := DecomposeProjectId(composedProjectId)
 	if err != nil {
 		return nil, err
 	}
@@ -414,7 +414,7 @@ func (r *repositoryResourceType) Revoke(ctx context.Context, grant *v2.Grant) (a
 		return nil, err
 	}
 
-	workspaceId, _, err := DecomposeProjectId(composedProjectId)
+	workspaceId, _, _, err := DecomposeProjectId(composedProjectId)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connector/repository.go
+++ b/pkg/connector/repository.go
@@ -200,7 +200,6 @@ func (r *repositoryResourceType) Grants(ctx context.Context, resource *v2.Resour
 			groupCopy := permission.Group
 
 			gr, err := userGroupResource(ctx, &groupCopy, &v2.ResourceId{Resource: workspaceId})
-
 			if err != nil {
 				return nil, "", nil, err
 			}

--- a/pkg/connector/user-group.go
+++ b/pkg/connector/user-group.go
@@ -164,12 +164,12 @@ func (ug *userGroupResourceType) Grant(ctx context.Context, principal *v2.Resour
 		return nil, fmt.Errorf("bitbucket-connector: only users can be granted group membership")
 	}
 
-	groupResourceId, groupSlug, err := ParseEntitlementID(entitlement.Id)
+	groupResourceId, _, err := ParseEntitlementID(entitlement.Id)
 	if err != nil {
 		return nil, err
 	}
 
-	workspaceId, _, err := DecomposeGroupId(groupResourceId.Resource)
+	workspaceId, groupSlug, err := DecomposeGroupId(groupResourceId.Resource)
 	if err != nil {
 		return nil, err
 	}
@@ -217,12 +217,12 @@ func (ug *userGroupResourceType) Revoke(ctx context.Context, grant *v2.Grant) (a
 		return nil, fmt.Errorf("bitbucket-connector: only users can have group membership revoked")
 	}
 
-	groupResourceId, groupSlug, err := ParseEntitlementID(entitlement.Id)
+	groupResourceId, _, err := ParseEntitlementID(entitlement.Id)
 	if err != nil {
 		return nil, err
 	}
 
-	workspaceId, _, err := DecomposeGroupId(groupResourceId.Resource)
+	workspaceId, groupSlug, err := DecomposeGroupId(groupResourceId.Resource)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit fixes provisioning.

On the C1 app the connectors do not read from the c1zs this leads to issues where we try to access the principal.Parent or entitlement.Profile and it is null. This previously caused panics, when we fixed the panics the provisioning was still broken. We now compose the ID's with all the necessary information and decompose them when we do provisioning.

Note for docs: if we want to allow read and write to user groups we need to add account permissions.