### PR TITLE
Anthony/bitbucket permission fix

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -6,7 +6,6 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 
-	"github.com/conductorone/baton-bitbucket/pkg/bitbucket"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -4,18 +4,14 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
-	"go.uber.org/zap"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"strings"
-
 	"github.com/conductorone/baton-bitbucket/pkg/bitbucket"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 )
 
 var (
@@ -132,18 +128,6 @@ func (bb *Bitbucket) checkPermissions(ctx context.Context, workspace *v2.Resourc
 		return false, err
 	}
 	return true, nil
-}
-
-func isPermissionDeniedErr(err error) bool {
-	e, ok := status.FromError(err)
-	if ok && e.Code() == codes.PermissionDenied {
-		return true
-	}
-	// In most cases the error code is unknown and the error message contains "status 403".
-	if (!ok || e.Code() == codes.Unknown) && strings.Contains(err.Error(), "status 403") {
-		return true
-	}
-	return false
 }
 
 // Validate hits the Bitbucket API to validate that the configured credentials are valid and compatible.

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -2,8 +2,6 @@ package connector
 
 import (
 	"fmt"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"strings"
 
 	"github.com/conductorone/baton-bitbucket/pkg/bitbucket"
@@ -92,16 +90,4 @@ func ParseEntitlementID(id string) (*v2.ResourceId, string, error) {
 		Resource:     strings.Join(parts[1:len(parts)-1], ":"),
 	}
 	return resourceId, parts[len(parts)-1], nil
-}
-
-func isPermissionDeniedErr(err error) bool {
-	e, ok := status.FromError(err)
-	if ok && e.Code() == codes.PermissionDenied {
-		return true
-	}
-	// In most cases the error code is unknown and the error message contains "status 403".
-	if (!ok || e.Code() == codes.Unknown) && strings.Contains(err.Error(), "status 403") {
-		return true
-	}
-	return false
 }

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -2,6 +2,8 @@ package connector
 
 import (
 	"fmt"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"strings"
 
 	"github.com/conductorone/baton-bitbucket/pkg/bitbucket"
@@ -90,4 +92,15 @@ func ParseEntitlementID(id string) (*v2.ResourceId, string, error) {
 		Resource:     strings.Join(parts[1:len(parts)-1], ":"),
 	}
 	return resourceId, parts[len(parts)-1], nil
+}
+func isPermissionDeniedErr(err error) bool {
+	e, ok := status.FromError(err)
+	if ok && e.Code() == codes.PermissionDenied {
+		return true
+	}
+	// In most cases the error code is unknown and the error message contains "status 403".
+	if (!ok || e.Code() == codes.Unknown) && strings.Contains(err.Error(), "status 403") {
+		return true
+	}
+	return false
 }

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -2,6 +2,8 @@ package connector
 
 import (
 	"fmt"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"strings"
 
 	"github.com/conductorone/baton-bitbucket/pkg/bitbucket"
@@ -90,4 +92,16 @@ func ParseEntitlementID(id string) (*v2.ResourceId, string, error) {
 		Resource:     strings.Join(parts[1:len(parts)-1], ":"),
 	}
 	return resourceId, parts[len(parts)-1], nil
+}
+
+func isPermissionDeniedErr(err error) bool {
+	e, ok := status.FromError(err)
+	if ok && e.Code() == codes.PermissionDenied {
+		return true
+	}
+	// In most cases the error code is unknown and the error message contains "status 403".
+	if (!ok || e.Code() == codes.Unknown) && strings.Contains(err.Error(), "status 403") {
+		return true
+	}
+	return false
 }

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -2,8 +2,6 @@ package connector
 
 import (
 	"fmt"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"strings"
 
 	"github.com/conductorone/baton-bitbucket/pkg/bitbucket"
@@ -11,6 +9,8 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var ResourcesPageSize = 50

--- a/pkg/connector/workspace.go
+++ b/pkg/connector/workspace.go
@@ -49,9 +49,6 @@ func (w *workspaceResourceType) List(ctx context.Context, _ *v2.ResourceId, toke
 	var rv []*v2.Resource
 
 	if w.client.IsUserScoped() {
-		if token == nil {
-			return nil, "", nil, fmt.Errorf("bitbucket-connector: invalid page token")
-		}
 		bag, err := parsePageToken(token.Token, &v2.ResourceId{ResourceType: resourceTypeWorkspace.Id})
 		if err != nil {
 			return nil, "", nil, err

--- a/pkg/connector/workspace.go
+++ b/pkg/connector/workspace.go
@@ -3,13 +3,6 @@ package connector
 import (
 	"context"
 	"fmt"
-	"strings"
-
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
-	"go.uber.org/zap"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/conductorone/baton-bitbucket/pkg/bitbucket"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
@@ -51,58 +44,6 @@ func workspaceResource(ctx context.Context, workspace *bitbucket.Workspace) (*v2
 	return resource, nil
 }
 
-func isPermissionDeniedErr(err error) bool {
-	e, ok := status.FromError(err)
-	if ok && e.Code() == codes.PermissionDenied {
-		return true
-	}
-	// In most cases the error code is unknown and the error message contains "status 403".
-	if (!ok || e.Code() == codes.Unknown) && strings.Contains(err.Error(), "status 403") {
-		return true
-	}
-	return false
-}
-func (w *workspaceResourceType) checkPermissions(ctx context.Context, workspace *bitbucket.Workspace) (bool, error) {
-	l := ctxzap.Extract(ctx)
-	logMissingPermission := func(obj string) {
-		l.Error(
-			"missing permission to list object in workspace",
-			zap.String("workspace", workspace.Slug),
-			zap.String("workspace id", workspace.Id),
-			zap.String("object", obj),
-		)
-	}
-	paginationVars := bitbucket.PaginationVars{
-		Limit: 1,
-		Page:  "",
-	}
-	_, err := w.client.GetWorkspaceUserGroups(ctx, workspace.Id)
-	if err != nil {
-		if isPermissionDeniedErr(err) {
-			logMissingPermission("userGroups")
-			return false, nil
-		}
-		return false, err
-	}
-	_, _, err = w.client.GetWorkspaceMembers(ctx, workspace.Id, paginationVars)
-	if err != nil {
-		if isPermissionDeniedErr(err) {
-			logMissingPermission("users")
-			return false, nil
-		}
-		return false, err
-	}
-	_, _, err = w.client.GetWorkspaceProjects(ctx, workspace.Id, paginationVars)
-	if err != nil {
-		if isPermissionDeniedErr(err) {
-			logMissingPermission("projects")
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
-}
-
 func (w *workspaceResourceType) List(ctx context.Context, _ *v2.ResourceId, token *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
 	var rv []*v2.Resource
 	if w.client.IsUserScoped() {
@@ -142,13 +83,6 @@ func (w *workspaceResourceType) List(ctx context.Context, _ *v2.ResourceId, toke
 			if err != nil {
 				return nil, "", nil, err
 			}
-			ok, err := w.checkPermissions(ctx, &workspaceCopy)
-			if err != nil {
-				return nil, "", nil, fmt.Errorf("bitbucket-connector: failed to verify permissions: %w", err)
-			}
-			if !ok {
-				continue
-			}
 			rv = append(rv, wr)
 		}
 
@@ -173,13 +107,6 @@ func (w *workspaceResourceType) List(ctx context.Context, _ *v2.ResourceId, toke
 	wr, err := workspaceResource(ctx, workspace)
 	if err != nil {
 		return nil, "", nil, err
-	}
-	ok, err := w.checkPermissions(ctx, workspace)
-	if err != nil {
-		return nil, "", nil, fmt.Errorf("bitbucket-connector: failed to verify permissions: %w", err)
-	}
-	if !ok {
-		return rv, "", nil, nil
 	}
 
 	rv = append(rv, wr)

--- a/pkg/connector/workspace.go
+++ b/pkg/connector/workspace.go
@@ -3,6 +3,7 @@ package connector
 import (
 	"context"
 	"fmt"
+
 	"github.com/conductorone/baton-bitbucket/pkg/bitbucket"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
@@ -46,6 +47,7 @@ func workspaceResource(ctx context.Context, workspace *bitbucket.Workspace) (*v2
 
 func (w *workspaceResourceType) List(ctx context.Context, _ *v2.ResourceId, token *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
 	var rv []*v2.Resource
+
 	if w.client.IsUserScoped() {
 		if token == nil {
 			return nil, "", nil, fmt.Errorf("bitbucket-connector: invalid page token")
@@ -83,11 +85,13 @@ func (w *workspaceResourceType) List(ctx context.Context, _ *v2.ResourceId, toke
 			if err != nil {
 				return nil, "", nil, err
 			}
+
 			rv = append(rv, wr)
 		}
 
 		return rv, pageToken, nil, nil
 	}
+
 	workspaceId, err := w.client.WorkspaceId()
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("bitbucket-connector: failed to get workspace id: %w", err)


### PR DESCRIPTION
I added a case to the isPermissionDenied function that was missing, unknown code but error messages contains the works "status 403". Additionally, I moved the validation from the list function to the validate function. I then set the bitbucket connector workspaces to only the ones that are valid.

I tested this and it worked, before this workspace would error.
<img width="826" alt="image" src="https://github.com/ConductorOne/baton-bitbucket/assets/60042005/05f1af33-26a4-4195-b3be-95f9b2643dee">
