### PR TITLE
Anthony/bitbucket permission fix 2

### DIFF
--- a/pkg/bitbucket/client.go
+++ b/pkg/bitbucket/client.go
@@ -172,10 +172,9 @@ func (c *Client) filterWorkspaces(ctx context.Context, workspaces []Workspace) (
 	for _, workspace := range workspaces {
 		// We call this function in order to initialize the workspaceID's map. In that case we need to return all workspaces,
 		// so they can be filtered and only the valid ones are set in the workspaceIds map.
-		if c.workspaceIDs != nil {
-			if _, ok := c.workspaceIDs[workspace.Id]; ok {
-				continue
-			}
+		_, ok := c.workspaceIDs[workspace.Id]
+		if c.workspaceIDs != nil && !ok {
+			continue
 		}
 
 		filteredWorkspaces = append(filteredWorkspaces, workspace)

--- a/pkg/bitbucket/client.go
+++ b/pkg/bitbucket/client.go
@@ -166,21 +166,18 @@ func (c *Client) checkPermissions(ctx context.Context, workspace *Workspace) (bo
 	return true, nil
 }
 
-func (c *Client) isValidWorkspaceId(workspaceId string) bool {
-	if c.workspaceIDs == nil || len(c.workspaceIDs) == 0 {
-		return true
-	}
-	_, ok := c.workspaceIDs[workspaceId]
-	return ok
-}
 func (c *Client) filterWorkspaces(ctx context.Context, workspaces []Workspace) ([]Workspace, error) {
 	filteredWorkspaces := make([]Workspace, 0)
 
 	for _, workspace := range workspaces {
-		// Check if workspace is in the list of allowed workspaces, which is empty if the list is not provided.
-		if !c.isValidWorkspaceId(workspace.Id) {
-			continue
+		// We can call this function in order to initialize the workspaceID's map. In that case we need to return all workspaces,
+		// so they can be filtered and only the valid ones are set in the workspaceIds map.
+		if c.workspaceIDs != nil {
+			if _, ok := c.workspaceIDs[workspace.Id]; ok {
+				continue
+			}
 		}
+
 		filteredWorkspaces = append(filteredWorkspaces, workspace)
 	}
 

--- a/pkg/bitbucket/client.go
+++ b/pkg/bitbucket/client.go
@@ -186,13 +186,13 @@ func (c *Client) filterWorkspaces(ctx context.Context, workspaces []Workspace) (
 // If client have access to multiple workspaces, method `WorkspaceIDs`
 // returns list of workspace ids otherwise it returns error.
 func (c *Client) SetWorkspaceIDs(ctx context.Context, workspaceIDs []string) error {
+	if !c.IsUserScoped() {
+		return status.Error(codes.InvalidArgument, "client is not user scoped")
+	}
 	c.workspaceIDs = make(map[string]bool)
 	givenWorkspaceIDs := make(map[string]bool)
 	for _, workspaceId := range workspaceIDs {
 		givenWorkspaceIDs[workspaceId] = true
-	}
-	if !c.IsUserScoped() {
-		return status.Error(codes.InvalidArgument, "client is not user scoped")
 	}
 
 	workspaces, err := c.GetAllWorkspaces(ctx)

--- a/pkg/bitbucket/client.go
+++ b/pkg/bitbucket/client.go
@@ -202,6 +202,7 @@ func (c *Client) SetWorkspaceIDs(ctx context.Context, workspaceIDs []string) err
 		}
 
 		for _, workspace := range workspaces {
+			workspace := workspace
 			if _, ok := givenWorkspaceIDs[workspace.Id]; !ok && len(givenWorkspaceIDs) > 0 {
 				continue
 			}

--- a/pkg/bitbucket/client.go
+++ b/pkg/bitbucket/client.go
@@ -3,13 +3,13 @@ package bitbucket
 import (
 	"context"
 	"fmt"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
-	"go.uber.org/zap"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -46,7 +46,7 @@ const (
 type Client struct {
 	wrapper      *uhttp.BaseHttpClient
 	scope        Scope
-	workspaceIds map[string]bool
+	workspaceIDs map[string]bool
 }
 
 func NewClient(httpClient *http.Client) *Client {
@@ -167,10 +167,10 @@ func (c *Client) checkPermissions(ctx context.Context, workspace *Workspace) (bo
 }
 
 func (c *Client) isValidWorkspaceId(workspaceId string) bool {
-	if c.workspaceIds == nil || len(c.workspaceIds) == 0 {
+	if c.workspaceIDs == nil || len(c.workspaceIDs) == 0 {
 		return true
 	}
-	_, ok := c.workspaceIds[workspaceId]
+	_, ok := c.workspaceIDs[workspaceId]
 	return ok
 }
 func (c *Client) filterWorkspaces(ctx context.Context, workspaces []Workspace) ([]Workspace, error) {
@@ -187,13 +187,13 @@ func (c *Client) filterWorkspaces(ctx context.Context, workspaces []Workspace) (
 	return filteredWorkspaces, nil
 }
 
-// If client have access to multiple workspaces, method `WorkspaceIds`
+// If client have access to multiple workspaces, method `WorkspaceIDs`
 // returns list of workspace ids otherwise it returns error.
-func (c *Client) SetWorkspaceIDs(ctx context.Context, workspaceIds []string) error {
-	c.workspaceIds = make(map[string]bool)
-	givenWorkspaceIds := make(map[string]bool)
-	for _, workspaceId := range workspaceIds {
-		givenWorkspaceIds[workspaceId] = true
+func (c *Client) SetWorkspaceIDs(ctx context.Context, workspaceIDs []string) error {
+	c.workspaceIDs = make(map[string]bool)
+	givenWorkspaceIDs := make(map[string]bool)
+	for _, workspaceId := range workspaceIDs {
+		givenWorkspaceIDs[workspaceId] = true
 	}
 	if c.IsUserScoped() {
 		workspaces, err := c.GetAllWorkspaces(ctx)
@@ -202,7 +202,7 @@ func (c *Client) SetWorkspaceIDs(ctx context.Context, workspaceIds []string) err
 		}
 
 		for _, workspace := range workspaces {
-			if _, ok := givenWorkspaceIds[workspace.Id]; !ok && len(givenWorkspaceIds) > 0 {
+			if _, ok := givenWorkspaceIDs[workspace.Id]; !ok && len(givenWorkspaceIDs) > 0 {
 				continue
 			}
 			ok, err := c.checkPermissions(ctx, &workspace)
@@ -212,12 +212,12 @@ func (c *Client) SetWorkspaceIDs(ctx context.Context, workspaceIds []string) err
 			if !ok {
 				continue
 			}
-			c.workspaceIds[workspace.Id] = true
+			c.workspaceIDs[workspace.Id] = true
 		}
 	} else {
 		return status.Error(codes.InvalidArgument, "client is not user scoped")
 	}
-	if len(c.workspaceIds) == 0 {
+	if len(c.workspaceIDs) == 0 {
 		return status.Error(codes.Unauthenticated, "no authenticated workspaces found")
 	}
 	return nil

--- a/pkg/bitbucket/client.go
+++ b/pkg/bitbucket/client.go
@@ -170,7 +170,7 @@ func (c *Client) filterWorkspaces(ctx context.Context, workspaces []Workspace) (
 	filteredWorkspaces := make([]Workspace, 0)
 
 	for _, workspace := range workspaces {
-		// We can call this function in order to initialize the workspaceID's map. In that case we need to return all workspaces,
+		// We call this function in order to initialize the workspaceID's map. In that case we need to return all workspaces,
 		// so they can be filtered and only the valid ones are set in the workspaceIds map.
 		if c.workspaceIDs != nil {
 			if _, ok := c.workspaceIDs[workspace.Id]; ok {

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -76,7 +76,7 @@ func (bb *Bitbucket) Validate(ctx context.Context) (annotations.Annotations, err
 	if err != nil {
 		return nil, err
 	}
-	
+
 	if bb.client.IsUserScoped() {
 		err = bb.client.SetWorkspaceIDs(ctx, bb.workspaces)
 		if err != nil {

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -8,10 +8,7 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
-	"go.uber.org/zap"
 )
 
 var (
@@ -68,78 +65,6 @@ func (bb *Bitbucket) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error
 	}, nil
 }
 
-// Get all the valid workspaces, ie. the workspaces that the user has access to.
-func (bb *Bitbucket) getValidWorkspaces(ctx context.Context) ([]string, error) {
-	workspaceObject := workspaceBuilder(bb.client, bb.workspaces)
-	pageToken := ""
-	workspaceResources := make([]*v2.Resource, 0)
-	for {
-		temp, pageToken, _, err := workspaceObject.List(ctx, nil, &pagination.Token{Token: pageToken})
-		if err != nil {
-			return nil, err
-		}
-		workspaceResources = append(workspaceResources, temp...)
-		if pageToken == "" {
-			break
-		}
-	}
-
-	validWorkspaces := make([]string, 0)
-	for _, workspace := range workspaceResources {
-		ok, err := bb.checkPermissions(ctx, workspace)
-		if err != nil {
-			return nil, fmt.Errorf("bitbucket-connector: failed to verify permissions: %w", err)
-		}
-		if !ok {
-			continue
-		}
-		validWorkspaces = append(validWorkspaces, workspace.DisplayName)
-	}
-	return validWorkspaces, nil
-}
-
-func (bb *Bitbucket) checkPermissions(ctx context.Context, workspace *v2.Resource) (bool, error) {
-	l := ctxzap.Extract(ctx)
-	logMissingPermission := func(obj string, err error) {
-		l.Error(
-			"missing permission to list object in workspace",
-			zap.String("workspace", workspace.DisplayName),
-			zap.String("workspace id", workspace.Id.Resource),
-			zap.String("object", obj),
-			zap.Error(err),
-		)
-	}
-	paginationVars := bitbucket.PaginationVars{
-		Limit: 1,
-		Page:  "",
-	}
-	_, err := bb.client.GetWorkspaceUserGroups(ctx, workspace.Id.Resource)
-	if err != nil {
-		if isPermissionDeniedErr(err) {
-			logMissingPermission("userGroups", err)
-			return false, nil
-		}
-		return false, err
-	}
-	_, _, err = bb.client.GetWorkspaceMembers(ctx, workspace.Id.Resource, paginationVars)
-	if err != nil {
-		if isPermissionDeniedErr(err) {
-			logMissingPermission("users", err)
-			return false, nil
-		}
-		return false, err
-	}
-	_, _, err = bb.client.GetWorkspaceProjects(ctx, workspace.Id.Resource, paginationVars)
-	if err != nil {
-		if isPermissionDeniedErr(err) {
-			logMissingPermission("projects", err)
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
-}
-
 // Validate hits the Bitbucket API to validate that the configured credentials are valid and compatible.
 func (bb *Bitbucket) Validate(ctx context.Context) (annotations.Annotations, error) {
 	// get the scope of used credentials
@@ -151,12 +76,12 @@ func (bb *Bitbucket) Validate(ctx context.Context) (annotations.Annotations, err
 	if err != nil {
 		return nil, err
 	}
-	bb.workspaces, err = bb.getValidWorkspaces(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("bitbucket-connector: failed to get valid workspaces: %w", err)
-	}
-	if len(bb.workspaces) == 0 {
-		return nil, fmt.Errorf("bitbucket-connector: no authorized workspaces found")
+	
+	if bb.client.IsUserScoped() {
+		err = bb.client.SetWorkspaceIDs(ctx, bb.workspaces)
+		if err != nil {
+			return nil, fmt.Errorf("bitbucket-connector: failed to get workspace ids: %w", err)
+		}
 	}
 	return nil, nil
 }

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -9,8 +9,6 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 var ResourcesPageSize = 50
@@ -92,15 +90,4 @@ func ParseEntitlementID(id string) (*v2.ResourceId, string, error) {
 		Resource:     strings.Join(parts[1:len(parts)-1], ":"),
 	}
 	return resourceId, parts[len(parts)-1], nil
-}
-func isPermissionDeniedErr(err error) bool {
-	e, ok := status.FromError(err)
-	if ok && e.Code() == codes.PermissionDenied {
-		return true
-	}
-	// In most cases the error code is unknown and the error message contains "status 403".
-	if (!ok || e.Code() == codes.Unknown) && strings.Contains(err.Error(), "status 403") {
-		return true
-	}
-	return false
 }


### PR DESCRIPTION
**Explanation**
By moving the validation code into the client and updating the `GetWorkspaces` method, which is used in all instances of listing workspaces, we will only get back workspaces with the proper permissions. This avoids any issues in the list user function where it doesn't have permissions.

Error on #18 :
`{ "error": "error: listing resources failed: bitbucket-connector: failed to list user: rpc error: code = Unknown desc = Request failed with status 403: Error: You do not have access to view this workspace." }`

Working on this PR:
<img width="1512" alt="image" src="https://github.com/ConductorOne/baton-bitbucket/assets/60042005/f22b0a35-b406-4003-bf47-aa407ed1796c">


**What was causing the bug**
This builds on #18 which was supposed to fix the syncing bug but there was a order of operations issue. We essentially want to switch steps 1 and 2. Alternatively, this PR adds validation further up the stream which achieves the same goal of validating before listing workspaces.

1. Call `ResourceSyncers`, including the `workspaceBuilder` using the empty workspaces`bb.workspaces = [] -> workspaceMap = {empty map}`
https://github.com/ConductorOne/baton-bitbucket/blob/bf29b39105ed63e0232e2e4ebd88131ad2f68e81/pkg/connector/connector.go#L54-L62
https://github.com/ConductorOne/baton-bitbucket/blob/bf29b39105ed63e0232e2e4ebd88131ad2f68e81/pkg/connector/workspace.go#L179-L189
2. Call `Validate`, which is supposed to return the valid workspaces `bb.workspaces = ["foo", "bar"]`.
https://github.com/ConductorOne/baton-bitbucket/blob/bf29b39105ed63e0232e2e4ebd88131ad2f68e81/pkg/connector/connector.go#L144-L154
3. Call `workspace.List` which checks the `workspace.slug` but the `w.workspaces = workspaceMap = {empty map}` and an empty map means there is no filtering going on `returns ["foo", "bar", "foobar"]`.
https://github.com/ConductorOne/baton-bitbucket/blob/bf29b39105ed63e0232e2e4ebd88131ad2f68e81/pkg/connector/workspace.go#L73-L77
4. Call `users.List` which iterates over the unvalidated workspaces, `["foo", "bar", "foobar"]`, and `"foobar"` is not in the valid workspaces, `["foo", "bar"]`, causing an error.
`{ "error": "error: listing resources failed: bitbucket-connector: failed to list user: rpc error: code = Unknown desc = Request failed with status 403: Error: You do not have access to view this workspace." }`

