### PR TITLE
Fix deprecated linter

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: 1.22.x
       - name: Set up Gon
-        run: brew tap mitchellh/gon && brew install mitchellh/gon/gon
+        run: brew tap conductorone/gon && brew install conductorone/gon/gon
       - name: Import Keychain Certs
         uses: apple-actions/import-codesign-certs@v1
         with:
@@ -32,6 +32,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELENG_GITHUB_TOKEN }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+          AC_PROVIDER: ${{ secrets.AC_PROVIDER }}
   goreleaser-docker:
     runs-on: ubuntu-latest
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,7 +57,6 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    - deadcode # Finds unused code
     - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
     - gosimple # Linter for Go source code that specializes in simplifying a code
     - govet # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
@@ -65,7 +64,6 @@ linters:
     - staticcheck # Staticcheck is a go vet on steroids, applying a ton of static analysis checks
     - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
     - unused # Checks Go code for unused constants, variables, functions and types
-    - varcheck # Finds unused global variables and constants
     - asasalint # Check for pass []any as any in variadic func(...any)
     - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
     - bidichk # Checks for dangerous unicode character sequences

--- a/.gon-amd64.json
+++ b/.gon-amd64.json
@@ -2,8 +2,7 @@
   "source": ["./dist/macos-amd64_darwin_amd64_v1/baton-bitbucket"],
   "bundle_id": "com.conductorone.baton-bitbucket",
   "apple_id": {
-    "username" : "justin.gallardo@conductorone.com",
-    "password":  "@env:AC_PASSWORD"
+    "username" : "justin.gallardo@conductorone.com"
   },
   "sign": {
     "application_identity": "Developer ID Application: Justin Gallardo (858DKH55XL)"

--- a/.gon-arm64.json
+++ b/.gon-arm64.json
@@ -2,8 +2,7 @@
   "source": ["./dist/macos-arm64_darwin_arm64/baton-bitbucket"],
   "bundle_id": "com.conductorone.baton-bitbucket",
   "apple_id": {
-    "username" : "justin.gallardo@conductorone.com",
-    "password":  "@env:AC_PASSWORD"
+    "username" : "justin.gallardo@conductorone.com"
   },
   "sign": {
     "application_identity": "Developer ID Application: Justin Gallardo (858DKH55XL)"


### PR DESCRIPTION
Fix deprecated linter

WARN The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused.
WARN The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused.
