### PR TITLE
Update connector page title to include parent company name

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Set up a Bitbucket connector"
+title:"Set up an Atlassian Bitbucket connector"
 description: "C1 provides identity governance for Bitbucket. Integrate your Bitbucket instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
-og:title: "Set up a Bitbucket connector"
+og:title:"Set up an Atlassian Bitbucket connector"
 og:description: "C1 provides identity governance for Bitbucket. Integrate your Bitbucket instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
 sidebarTitle: "Atlassian Bitbucket"
 ---
@@ -60,7 +60,7 @@ Configuring the connector requires you to pass in credentials generated in Bitbu
     </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 
 ## Configure the Bitbucket connector
 
@@ -116,7 +116,7 @@ Configuring the connector requires you to pass in credentials generated in Bitbu
     </Step>
 </Steps>
 
-**That's it!** Your Bitbucket connector is now pulling access data into C1.
+**Done.** Your Bitbucket connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 **Follow these instructions to use the Bitbucket connector, hosted and run in your own environment.**
@@ -232,7 +232,7 @@ spec:
     </Step>
 </Steps>
 
-**That's it!** Your Bitbucket connector is now pulling access data into C1.
+**Done.** Your Bitbucket connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,7 +1,7 @@
 ---
-title:"Set up an Atlassian Bitbucket connector"
+title: "Set up an Atlassian Bitbucket connector"
 description: "C1 provides identity governance for Bitbucket. Integrate your Bitbucket instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
-og:title:"Set up an Atlassian Bitbucket connector"
+og:title: "Set up an Atlassian Bitbucket connector"
 og:description: "C1 provides identity governance for Bitbucket. Integrate your Bitbucket instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
 sidebarTitle: "Atlassian Bitbucket"
 ---


### PR DESCRIPTION
This PR updates the connector page title and og:title to include the parent company name for better discoverability and consistency across connector docs.

Also replaces any remaining instances of `That's it!` with `Done.`