### PR TITLE
CXP-658 Update the workspaces endpoint

### DIFF
--- a/pkg/bitbucket/client.go
+++ b/pkg/bitbucket/client.go
@@ -18,6 +18,7 @@ const (
 	V1BaseURL = "https://api.bitbucket.org/1.0/"
 	BaseURL   = "https://api.bitbucket.org/2.0/"
 
+	UserWorkspacesBaseURL      = BaseURL + "user/workspaces"
 	WorkspacesBaseURL          = BaseURL + "workspaces"
 	WorkspaceBaseURL           = WorkspacesBaseURL + "/%s"
 	WorkspaceMembersBaseURL    = WorkspacesBaseURL + "/%s/members"
@@ -133,7 +134,7 @@ func (c *Client) checkPermissions(ctx context.Context, workspace *Workspace) (bo
 		l.Error(
 			"missing permission to list object in workspace",
 			zap.String("workspace", workspace.Slug),
-			zap.String("workspace id", workspace.Id),
+			zap.String("workspace_uuid", workspace.Id),
 			zap.String("object", obj),
 			zap.Error(err),
 		)
@@ -142,7 +143,7 @@ func (c *Client) checkPermissions(ctx context.Context, workspace *Workspace) (bo
 		Limit: 1,
 		Page:  "",
 	}
-	_, err := c.GetWorkspaceUserGroups(ctx, workspace.Id)
+	_, err := c.GetWorkspaceUserGroups(ctx, workspace.Slug)
 	if err != nil {
 		if isPermissionDeniedErr(err) {
 			logMissingPermission("userGroups", err)
@@ -150,7 +151,7 @@ func (c *Client) checkPermissions(ctx context.Context, workspace *Workspace) (bo
 		}
 		return false, err
 	}
-	_, _, err = c.GetWorkspaceMembers(ctx, workspace.Id, paginationVars)
+	_, _, err = c.GetWorkspaceMembers(ctx, workspace.Slug, paginationVars)
 	if err != nil {
 		if isPermissionDeniedErr(err) {
 			logMissingPermission("users", err)
@@ -158,7 +159,7 @@ func (c *Client) checkPermissions(ctx context.Context, workspace *Workspace) (bo
 		}
 		return false, err
 	}
-	_, _, err = c.GetWorkspaceProjects(ctx, workspace.Id, paginationVars)
+	_, _, err = c.GetWorkspaceProjects(ctx, workspace.Slug, paginationVars)
 	if err != nil {
 		if isPermissionDeniedErr(err) {
 			logMissingPermission("projects", err)
@@ -192,6 +193,7 @@ func (c *Client) SetWorkspaceIDs(ctx context.Context, workspaceIDs []string) err
 	if !c.IsUserScoped() {
 		return status.Error(codes.InvalidArgument, "client is not user scoped")
 	}
+
 	c.workspaceIDs = make(map[string]bool)
 	givenWorkspaceIDs := make(map[string]bool)
 	for _, workspaceId := range workspaceIDs {
@@ -205,7 +207,8 @@ func (c *Client) SetWorkspaceIDs(ctx context.Context, workspaceIDs []string) err
 
 	for _, workspace := range workspaces {
 		workspace := workspace
-		if _, ok := givenWorkspaceIDs[workspace.Id]; !ok && len(givenWorkspaceIDs) > 0 {
+		// --workspaces flag accepts slugs; UUID is stored as the map key for downstream consistency
+		if _, ok := givenWorkspaceIDs[workspace.Slug]; !ok && len(givenWorkspaceIDs) > 0 {
 			continue
 		}
 		ok, err := c.checkPermissions(ctx, &workspace)
@@ -224,17 +227,19 @@ func (c *Client) SetWorkspaceIDs(ctx context.Context, workspaceIDs []string) err
 }
 
 // GetWorkspaces lists all workspaces current user belongs to.
+// The /2.0/user/workspaces endpoint wraps each workspace in a workspace_access envelope;
+// this method unwraps it and returns canonical Workspace values.
 func (c *Client) GetWorkspaces(ctx context.Context, getWorkspacesVars PaginationVars) ([]Workspace, string, error) {
-	urlAddress, err := url.Parse(WorkspacesBaseURL)
+	urlAddress, err := url.Parse(UserWorkspacesBaseURL)
 	if err != nil {
 		return nil, "", err
 	}
 
-	var workspacesResponse ListResponse[Workspace]
+	var accessResponse ListResponse[DetailedWorkspace]
 	err = c.get(
 		ctx,
 		urlAddress,
-		&workspacesResponse,
+		&accessResponse,
 		[]QueryParam{
 			&getWorkspacesVars,
 			prepareFilters(""),
@@ -243,6 +248,15 @@ func (c *Client) GetWorkspaces(ctx context.Context, getWorkspacesVars Pagination
 	if err != nil {
 		return nil, "", err
 	}
+
+	workspacesResponse := ListResponse[Workspace]{PaginationData: accessResponse.PaginationData}
+	for _, item := range accessResponse.Values {
+		workspacesResponse.Values = append(workspacesResponse.Values, Workspace{
+			BaseResource: BaseResource{Id: item.Workspace.Uuid},
+			Slug:         item.Workspace.Slug,
+		})
+	}
+
 	workspacesResponse.Values, err = c.filterWorkspaces(ctx, workspacesResponse.Values)
 	if err != nil {
 		return nil, "", err
@@ -291,9 +305,7 @@ func (c *Client) GetWorkspace(ctx context.Context, workspaceId string) (*Workspa
 		ctx,
 		urlAddress,
 		&workspaceResponse,
-		[]QueryParam{
-			prepareFilters(""),
-		},
+		[]QueryParam{prepareFilters("")},
 	)
 	if err != nil {
 		if isPermissionDeniedErr(err) {

--- a/pkg/bitbucket/client.go
+++ b/pkg/bitbucket/client.go
@@ -235,7 +235,7 @@ func (c *Client) GetWorkspaces(ctx context.Context, getWorkspacesVars Pagination
 		return nil, "", err
 	}
 
-	var accessResponse ListResponse[DetailedWorkspace]
+	var accessResponse ListResponse[WorkspaceAccess]
 	err = c.get(
 		ctx,
 		urlAddress,
@@ -252,7 +252,7 @@ func (c *Client) GetWorkspaces(ctx context.Context, getWorkspacesVars Pagination
 	workspacesResponse := ListResponse[Workspace]{PaginationData: accessResponse.PaginationData}
 	for _, item := range accessResponse.Values {
 		workspacesResponse.Values = append(workspacesResponse.Values, Workspace{
-			BaseResource: BaseResource{Id: item.Workspace.Uuid},
+			BaseResource: BaseResource{Id: item.Workspace.UUID},
 			Slug:         item.Workspace.Slug,
 		})
 	}

--- a/pkg/bitbucket/models.go
+++ b/pkg/bitbucket/models.go
@@ -10,6 +10,26 @@ type Workspace struct {
 	Name string `json:"name"`
 }
 
+type DetailedWorkspace struct {
+	Type          string     `json:"type"`
+	Administrator bool       `json:"administrator"`
+	Workspace     DWorkspace `json:"workspace"`
+}
+
+type DWorkspace struct {
+	Type  string `json:"type"`
+	Uuid  string `json:"uuid"`
+	Slug  string `json:"slug"`
+	Links struct {
+		Avatar struct {
+			Href string `json:"href"`
+		} `json:"avatar"`
+		Self struct {
+			Href string `json:"href"`
+		} `json:"self"`
+	} `json:"links"`
+}
+
 type WorkspaceMember struct {
 	User User `json:"user"`
 }

--- a/pkg/bitbucket/models.go
+++ b/pkg/bitbucket/models.go
@@ -10,24 +10,16 @@ type Workspace struct {
 	Name string `json:"name"`
 }
 
-type DetailedWorkspace struct {
-	Type          string     `json:"type"`
-	Administrator bool       `json:"administrator"`
-	Workspace     DWorkspace `json:"workspace"`
+type WorkspaceAccess struct {
+	Type          string        `json:"type"`
+	Administrator bool          `json:"administrator"`
+	Workspace     WorkspaceBase `json:"workspace"`
 }
 
-type DWorkspace struct {
-	Type  string `json:"type"`
-	Uuid  string `json:"uuid"`
-	Slug  string `json:"slug"`
-	Links struct {
-		Avatar struct {
-			Href string `json:"href"`
-		} `json:"avatar"`
-		Self struct {
-			Href string `json:"href"`
-		} `json:"self"`
-	} `json:"links"`
+type WorkspaceBase struct {
+	Type string `json:"type"`
+	UUID string `json:"uuid"`
+	Slug string `json:"slug"`
 }
 
 type WorkspaceMember struct {

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -48,7 +48,7 @@ type Bitbucket struct {
 	workspaces []string
 }
 
-func (bb *Bitbucket) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncer {
+func (bb *Bitbucket) ResourceSyncers(_ context.Context) []connectorbuilder.ResourceSyncer {
 	return []connectorbuilder.ResourceSyncer{
 		workspaceBuilder(bb.client, bb.workspaces),
 		projectBuilder(bb.client),
@@ -59,7 +59,7 @@ func (bb *Bitbucket) ResourceSyncers(ctx context.Context) []connectorbuilder.Res
 }
 
 // Metadata returns metadata about the connector.
-func (bb *Bitbucket) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error) {
+func (bb *Bitbucket) Metadata(_ context.Context) (*v2.ConnectorMetadata, error) {
 	return &v2.ConnectorMetadata{
 		DisplayName: "Bitbucket",
 	}, nil
@@ -67,7 +67,6 @@ func (bb *Bitbucket) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error
 
 // Validate hits the Bitbucket API to validate that the configured credentials are valid and compatible.
 func (bb *Bitbucket) Validate(ctx context.Context) (annotations.Annotations, error) {
-	// get the scope of used credentials
 	user, err := bb.client.GetCurrentUser(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("bitbucket-connector: failed to get current user: %w", err)
@@ -83,6 +82,7 @@ func (bb *Bitbucket) Validate(ctx context.Context) (annotations.Annotations, err
 			return nil, fmt.Errorf("bitbucket-connector: failed to get workspace ids: %w", err)
 		}
 	}
+
 	return nil, nil
 }
 

--- a/pkg/connector/user-group.go
+++ b/pkg/connector/user-group.go
@@ -73,7 +73,13 @@ func (ug *userGroupResourceType) List(ctx context.Context, parentId *v2.Resource
 		return nil, "", nil, nil
 	}
 
-	userGroups, err := ug.client.GetWorkspaceUserGroups(ctx, parentId.Resource)
+	// V1 groups API requires the workspace slug, not UUID. Look up the workspace to get it.
+	workspace, err := ug.client.GetWorkspace(ctx, parentId.Resource)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("bitbucket-connector: failed to get workspace: %w", err)
+	}
+
+	userGroups, err := ug.client.GetWorkspaceUserGroups(ctx, workspace.Slug)
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("bitbucket-connector: failed to list userGroups: %w", err)
 	}
@@ -168,10 +174,16 @@ func (ug *userGroupResourceType) Grant(ctx context.Context, principal *v2.Resour
 		return nil, err
 	}
 
+	// V1 groups API requires the workspace slug, not UUID.
+	workspace, err := ug.client.GetWorkspace(ctx, workspaceId)
+	if err != nil {
+		return nil, fmt.Errorf("bitbucket-connector: failed to get workspace: %w", err)
+	}
+
 	userId := principal.Id.Resource
 
 	// check if user is already a member of the group
-	members, err := ug.client.GetUserGroupMembers(ctx, workspaceId, groupSlug)
+	members, err := ug.client.GetUserGroupMembers(ctx, workspace.Slug, groupSlug)
 	if err != nil {
 		return nil, fmt.Errorf("bitbucket-connector: failed to get user group members: %w", err)
 	}
@@ -187,7 +199,7 @@ func (ug *userGroupResourceType) Grant(ctx context.Context, principal *v2.Resour
 	}
 
 	// add user to the group
-	err = ug.client.AddUserToGroup(ctx, workspaceId, groupSlug, userId)
+	err = ug.client.AddUserToGroup(ctx, workspace.Slug, groupSlug, userId)
 	if err != nil {
 		return nil, fmt.Errorf("bitbucket-connector: failed to add user to user group: %w", err)
 	}
@@ -221,9 +233,15 @@ func (ug *userGroupResourceType) Revoke(ctx context.Context, grant *v2.Grant) (a
 		return nil, err
 	}
 
+	// V1 groups API requires the workspace slug, not UUID.
+	workspace, err := ug.client.GetWorkspace(ctx, workspaceId)
+	if err != nil {
+		return nil, fmt.Errorf("bitbucket-connector: failed to get workspace: %w", err)
+	}
+
 	userId := principal.Id.Resource
 
-	members, err := ug.client.GetUserGroupMembers(ctx, workspaceId, groupSlug)
+	members, err := ug.client.GetUserGroupMembers(ctx, workspace.Slug, groupSlug)
 	if err != nil {
 		return nil, fmt.Errorf("bitbucket-connector: failed to get user group members: %w", err)
 	}
@@ -237,8 +255,8 @@ func (ug *userGroupResourceType) Revoke(ctx context.Context, grant *v2.Grant) (a
 
 		return nil, fmt.Errorf("bitbucket-connector: user is not a member of the group")
 	}
-	// add user to the group
-	err = ug.client.RemoveUserFromGroup(ctx, workspaceId, groupSlug, userId)
+	// remove user from the group
+	err = ug.client.RemoveUserFromGroup(ctx, workspace.Slug, groupSlug, userId)
 	if err != nil {
 		return nil, fmt.Errorf("bitbucket-connector: failed to remove user from user group: %w", err)
 	}


### PR DESCRIPTION
Atlassian deprecated the endpoint on CHANGE-5770.
This PR switches the request to the new indicated endpoint and adjusts the code to work with the new response data trying to make the least changes possible and without modifying core data such as IDs or profile values.