### PR TITLE
CXP-671 Set the fields that were hidden on C1 as CLIOnly

### DIFF
--- a/config_schema.json
+++ b/config_schema.json
@@ -111,39 +111,10 @@
       "stringField": {}
     },
     {
-      "name": "token",
-      "displayName": "Access token",
-      "description": "Access token (workspace or project scoped) used to connect to the Bitbucket API.",
-      "isSecret": true,
-      "stringField": {}
-    },
-    {
-      "name": "consumer-key",
-      "displayName": "Consumer key",
-      "description": "OAuth consumer key used to connect to the Bitbucket API via OAuth.",
-      "stringField": {}
-    },
-    {
-      "name": "consumer-secret",
-      "displayName": "Consumer Secret",
-      "description": "The consumer secret used to connect to the Bitbucket API via OAuth.",
-      "isSecret": true,
-      "stringField": {}
-    },
-    {
       "name": "workspaces",
       "displayName": "Workspaces",
       "description": "Limit syncing to specific workspaces by specifying workspace slugs.",
       "stringSliceField": {}
-    }
-  ],
-  "constraints": [
-    {
-      "kind": "CONSTRAINT_KIND_REQUIRED_TOGETHER",
-      "fieldNames": [
-        "consumer-key",
-        "consumer-secret"
-      ]
     }
   ],
   "displayName": "Bitbucket",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,17 +22,20 @@ var (
 		field.WithDisplayName("Access token"),
 		field.WithDescription("Access token (workspace or project scoped) used to connect to the Bitbucket API."),
 		field.WithIsSecret(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 	ConsumerKeyField = field.StringField(
 		"consumer-key",
 		field.WithDisplayName("Consumer key"),
 		field.WithDescription("OAuth consumer key used to connect to the Bitbucket API via OAuth."),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 	ConsumerSecretField = field.StringField(
 		"consumer-secret",
 		field.WithDisplayName("Consumer Secret"),
 		field.WithDescription("The consumer secret used to connect to the Bitbucket API via OAuth."),
 		field.WithIsSecret(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 	WorkspacesField = field.StringSliceField(
 		"workspaces",


### PR DESCRIPTION
Some fields were not visible on C1 when the connector wasn't containerized yet.
Now, with the containerization, they all show, so we are setting the ones that were hidden as CLIOnly to keep it as it was.